### PR TITLE
Standardize "post-quantum"

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,7 +1,7 @@
-The migration to postquantum cryptography is being held back by buggy servers
+The migration to post-quantum cryptography is being held back by buggy servers
 that do not correctly implement TLS. These servers reject connections that use
-postquantum-secure cryptography, instead of negotiating classical cryptography
-if they do not support the experiment postquantum algorithms.
+post-quantum-secure cryptography, instead of negotiating classical cryptography
+if they do not support the experiment post-quantum algorithms.
 
 ## What is the bug?
 
@@ -13,23 +13,23 @@ important to migrate to cryptography that cannot be broken by a quantum computer
 _before_ quantum computers exist.
 
 Unfortunately, some buggy servers are not prepared for clients to start
-supporting postquantum-secure cryptography. The TLS protocol contains a
+supporting post-quantum-secure cryptography. The TLS protocol contains a
 mechanism for the server and client to negotiate the cryptographic algorithms
 used for the connection based on which algorithms are mutally supported by both.
 This means that correctly-implemented servers that have no yet added support for
-the draft postquantum algorithms should silently ignore the postquantum option,
+the draft post-quantum algorithms should silently ignore the post-quantum option,
 and select a different classical algorithm.
 
-TLS ClientHello messages that offer postquantum cryptography are larger than
+TLS ClientHello messages that offer post-quantum cryptography are larger than
 classical ClientHello messages, and exceed the threshold for transmission in a
 single packet. This means that a single call to TCP `read()` might not return
 the entire ClientHello packet. This has always been possible in TCP, but it is
 exacerbated by the larger ClientHello messages. Most buggy servers are not
 prepared to have to call `read()` more than once to read the entire ClientHello.
-This is still a bug even prior to the postquantum migration, however, the bug is
-much more commonly exposed when the larger postquantum cryptography is in use.
+This is still a bug even prior to the post-quantum migration, however, the bug is
+much more commonly exposed when the larger post-quantum cryptography is in use.
 
-## What is postquantum-secure cryptography?
+## What is post-quantum-secure cryptography?
 
 Modern public-key cryptography is secure in the face of a classical computer,
 but can be broken by a quantum computer. Luckily, quantum computers don't exist
@@ -40,20 +40,20 @@ yet!
 Future quantum computers pose a risk to current Internet traffic through
 store-then-decrypt attacks, in which attackers harvest encrypted sensitive
 information now, and then decrypt it later, once quantum computers exist.
-Mitigating this threat requires deploying a postquantum key exchange mechanism
+Mitigating this threat requires deploying a post-quantum key exchange mechanism
 _now_.
 
 ## What about authentication?
 
 Quantum computers are capable of breaking the digital signature algorithms used for authenticating
-digital communications today. Postquantum signature algorithms exist, but still
+digital communications today. Post-quantum signature algorithms exist, but still
 have performance issues that make them difficult to integrate into existing
 authentication systems, such as HTTPS certificates (X.509). Luckily, unlike key
 exchange, the risk to authentication from a quantum computer requires a quantum
 computer to actually exist, since connections are authenticated in realtime. The
 store-then-decrypt attack does not apply to authentication algorithms.
 
-This means the migration to postquantum secure authentication algorithms is less
+This means the migration to post-quantum secure authentication algorithms is less
 urgent than key exchange. Due to the slow moving nature of the authentication
 ecosystems on the Internet, such as the Web PKI, it is important to start this
 migration soon.  However, there is no urgent threat to authentication, like
@@ -74,13 +74,13 @@ connection, especially if it split over two packets. This is less likely with
 classical cryptography, but can happen. You can test for this by sending "half"
 a ClientHello, and then waiting before sending the rest, and seeing if the
 server correctly handles the connection, or if it resets the connection. This
-bug is not specific to postquantum cryptography, but is exacerbated by it.
+bug is not specific to post-quantum cryptography, but is exacerbated by it.
 
-## How does this affect the migration to postquantum cryptography?
+## How does this affect the migration to post-quantum cryptography?
 
 TODO
 
-## I'm ot migrating to postquantum cryptography until later. Why do I need to do anything now?
+## I'm ot migrating to post-quantum cryptography until later. Why do I need to do anything now?
 
 TODO
 
@@ -92,8 +92,8 @@ The bug is that servers don't read the whole ClientHello, likely because it was
 ## This isn't a vulnerability, why do you have a website?
 
 This bug appears in a lot of servers and is holding back the Internet's
-migration to postquantum secure cryptography. If things were operating
-correctly, clients could deploy support for postquantum cryptography and then
+migration to post-quantum secure cryptography. If things were operating
+correctly, clients could deploy support for post-quantum cryptography and then
 servers would slowly opt-in. Instead, we're stuck, because properly implemented
-clients that deploy postquantum cryptography can completely fail to open
+clients that deploy post-quantum cryptography can completely fail to open
 connections to buggy servers.


### PR DESCRIPTION
As popularized by NIST, standardize on "post-quantum" over "postquantum."

More at: https://csrc.nist.gov/projects/post-quantum-cryptography

[OCD was triggered, going back into my hole now.]