### PR TITLE
iOS 26 already supported PQC

### DIFF
--- a/index.md
+++ b/index.md
@@ -163,7 +163,7 @@ Browser | Windows        | Mac           | Linux         | ChromeOS      | Andro
 ------- | -------------- | ------------- | ------------- | ------------- | -------------------- | -----------
 Chrome  | Chrome 124     | Chrome 124    | Chrome 124    | Chrome 124    | Chrome 131           | n/a[^1]
 Firefox | `about:config` |`about:config` |`about:config` | n/a[^2]       |`about:config`        | n/a[^1]
-Safari  | Unavailable    | Unavailable   | Unavailable   | n/a[^2]       | n/a[^3]              | Unavailable
+Safari  | Unavailable    | Unavailable   | Unavailable   | n/a[^2]       | n/a[^3]              | iOS 26
 
 ## Known Incompatibilities
 


### PR DESCRIPTION
As https://support.apple.com/en-us/122756

>In iOS 26, iPadOS 26, macOS Tahoe 26, and visionOS 26, TLS-protected connections will automatically advertise support for hybrid, quantum-secure key exchange in TLS 1.3.